### PR TITLE
Faster cold start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         RUN python -c 'import streamlit, dhlab, pandas, requests'
         RUN timeout 5s streamlit run emneord.py; exit 0
 
-        CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord-test-fast
-        CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord
+        CMD streamlit run emneord.py \
+            --server.port ${PORT} \
+            --browser.gatherUsageStats=False \
+            --server.baseUrlPath /emneord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-slim-bookworm
         ENV PORT=8501
         EXPOSE $PORT
         WORKDIR /emneord.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
         # Warm up caches
         RUN python -c 'import streamlit, dhlab, pandas, requests'
-        RUN timeout 5s streamlit run emneord.py; exit 0
+        RUN timeout 5s streamlit hello; exit 0
 
         CMD streamlit run emneord.py \
             --server.port ${PORT} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         COPY ./emneord.py .
 
         # Warm up caches
-        RUN timeout 5s streamlit emneord.py; exit 0
+        RUN timeout 5s streamlit run emneord.py; exit 0
         RUN python -c 'import dhlab, pandas'
 
         CMD streamlit run emneord.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         WORKDIR /emneord.py
         COPY requirements.txt ./requirements.txt
         RUN uv pip install --system --compile-bytecode --only-binary=:all: --no-binary=python-louvain -r requirements.txt
+        RUN python -c 'import streamlit, dhlab, pandas, requests'
         COPY ./emneord.py .
         CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,16 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         ENV PORT=8501
         EXPOSE $PORT
         WORKDIR /emneord.py
+
         COPY requirements.txt ./requirements.txt
         RUN uv pip install --system --compile-bytecode --only-binary=:all: --no-binary=python-louvain -r requirements.txt
-        RUN python -c 'import streamlit, dhlab, pandas, requests'
+
         COPY ./emneord.py .
+
+        # Warm up caches
+        RUN python -c 'import streamlit, dhlab, pandas, requests'
+        RUN timeout 5s streamlit run emneord.py; exit 0
+
+        CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord-test-fast
         CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.12-slim-bookworm
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         ENV PORT=8501
         EXPOSE $PORT
         WORKDIR /emneord.py
         COPY requirements.txt ./requirements.txt
-        RUN pip3 install -r requirements.txt
+        RUN uv pip install --system -r requirements.txt
         COPY . .
         CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         EXPOSE $PORT
         WORKDIR /emneord.py
         COPY requirements.txt ./requirements.txt
-        RUN uv pip install --system -r requirements.txt
+        RUN uv pip install --system --compile-bytecode --only-binary=:all: --no-binary=python-louvain -r requirements.txt
         COPY . .
         CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         WORKDIR /emneord.py
         COPY requirements.txt ./requirements.txt
         RUN uv pip install --system --compile-bytecode --only-binary=:all: --no-binary=python-louvain -r requirements.txt
-        COPY . .
+        COPY ./emneord.py .
         CMD streamlit run emneord.py --server.port ${PORT} --server.baseUrlPath /emneord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
         COPY ./emneord.py .
 
         # Warm up caches
-        RUN python -c 'import streamlit, dhlab, pandas, requests'
-        RUN timeout 5s streamlit hello; exit 0
+        RUN timeout 5s streamlit emneord.py; exit 0
+        RUN python -c 'import dhlab, pandas'
 
         CMD streamlit run emneord.py \
             --server.port ${PORT} \

--- a/emneord.py
+++ b/emneord.py
@@ -1,5 +1,4 @@
 import streamlit as st
-import pandas as pd
 import re
 from collections import Counter
 
@@ -7,6 +6,7 @@ COL_FREQ = "frekvens"
 
 @st.cache_data(show_spinner=False)
 def get_topic_counts(corpus, column='subjects'):
+    import pandas as pd
     try:
         emneord =  Counter([x.strip() 
                         for y in corpus[column].values 
@@ -19,6 +19,7 @@ def get_topic_counts(corpus, column='subjects'):
     return emner
 
 def process_corpus(corpus):
+    import pandas as pd
     corpusdf = corpus.corpus.fillna("")
     corpusdf.year = pd.to_datetime(corpusdf.year.map(lambda x:str(int(x))), format="mixed")
     corpusdf.timestamp = pd.to_datetime(corpusdf.timestamp.map(lambda x:str(int(x))), format="mixed")
@@ -61,6 +62,7 @@ def process_corpus(corpus):
         st.write(f"Korpusstørrelsen er {len(corpusdf)}.")
 
 def get_corpus(urner="", file=None):
+    import pandas as pd
     corpus = None
 
     if file is not None:
@@ -101,5 +103,6 @@ corpus = get_corpus(urner, uploaded_file)
 if corpus is None:
     st.write(' -- venter på korpus --')
     import dhlab as _
+    import pandas as _
 else:
     process_corpus(corpus)

--- a/emneord.py
+++ b/emneord.py
@@ -1,4 +1,3 @@
-import dhlab as dh
 import streamlit as st
 import pandas as pd
 import re
@@ -19,10 +18,10 @@ def get_topic_counts(corpus, column='subjects'):
     emner = pd.DataFrame.from_dict(emneord, orient='index', columns=[COL_FREQ]).sort_values(by = COL_FREQ, ascending=False)
     return emner
 
-def process_corpus(corpus: dh.Corpus):
+def process_corpus(corpus):
     corpusdf = corpus.corpus.fillna("")
-    corpusdf.year = pd.to_datetime(corpusdf.year.map(lambda x:str(int(x))))
-    corpusdf.timestamp = pd.to_datetime(corpusdf.timestamp.map(lambda x:str(int(x))))
+    corpusdf.year = pd.to_datetime(corpusdf.year.map(lambda x:str(int(x))), format="mixed")
+    corpusdf.timestamp = pd.to_datetime(corpusdf.timestamp.map(lambda x:str(int(x))), format="mixed")
 
     col1, col2 = st.columns(2)
     with col1:
@@ -61,6 +60,25 @@ def process_corpus(corpus: dh.Corpus):
         st.write(f"Antall _{gruppering}_ er {len(df)}.")
         st.write(f"Korpusstørrelsen er {len(corpusdf)}.")
 
+def get_corpus(urner="", file=None):
+    corpus = None
+
+    if file is not None:
+        import dhlab as dh
+        dataframe = pd.read_excel(file)
+        corpus = dh.Corpus(doctype='digibok',limit=0)
+        corpus.extend_from_identifiers(list(dataframe.urn))
+    elif urner != "":
+        import dhlab as dh
+        urns = re.findall(r"URN:NBN[^\s.,]+", urner)
+        if urns != []:
+            corpus = dh.Corpus(doctype='digibok',limit=0)
+            corpus.extend_from_identifiers(urns)
+        else:
+            st.write('Fant ingen URNer')
+
+    return corpus
+
 
 st.set_page_config(
     page_title="Metadata",
@@ -73,27 +91,15 @@ st.set_page_config(
 st.sidebar.markdown("Velg et korpus fra [corpus-appen](https://beta.nb.no/dhlab/corpus/)" 
                     " eller hent en eller flere URNer fra nb.no eller andre steder")
 
-
-corpus = None
-
 urner = st.sidebar.text_area("Lim inn URNer:","", help="Lim en tekst som har URNer i seg. Teksten trenger ikke å være formatert")
-if urner != "":
-    urns = re.findall(r"URN:NBN[^\s.,]+", urner)
-    if urns != []:
-        corpus = dh.Corpus(doctype='digibok',limit=0)
-        corpus.extend_from_identifiers(urns)
-    else:
-        st.write('Fant ingen URNer')
-
 uploaded_file = st.sidebar.file_uploader("Last opp et korpus", help="Dra en fil over hit, fra et nedlastningsikon, eller velg fra en mappe")
-if uploaded_file is not None:
-    dataframe = pd.read_excel(uploaded_file)
-    corpus = dh.Corpus(doctype='digibok',limit=0)
-    corpus.extend_from_identifiers(list(dataframe.urn))
 
 st.header('Inspiser metadata')
 
+corpus = get_corpus(urner, uploaded_file)
+
 if corpus is None:
     st.write(' -- venter på korpus --')
+    import dhlab as _
 else:
     process_corpus(corpus)


### PR DESCRIPTION
### Summary
* Use slim docker image
  - Faster container launch and build
* Use uv instead of pip
  - Faster builds
* Warm up python and streamlit caches by pre-running `python -c "import ..."` and `streamlit run hello`
  - Faster streamlit server launch and import loading
* Lazy-load imports
  - Much faster UI loading

### Dockerfile optimization samples from dhlab-app-dokumentstatistikk:
Total importtime until accepting incoming requests:
* 0.535s - `--compile-bytecode` only (default behavior in non-uv pip)
* 0.286s - `--compile-bytecode` and `streamlit run document_statistics.py`
* 0.288s - `--compile-bytecode` and `streamlit run document_statistics.py` + `import ...`

Total importtime after lazy imports:
* 2.434s - `--compile-bytecode` only (default behavior in non-uv pip)
* 2.155s - `--compile-bytecode` + `streamlit run document_statistics.py`
* 1.761s - `--compile-bytecode` + `streamlit run document_statistics.py` + `import ...`
